### PR TITLE
[processor/lookupprocessor] Add lookup processor implementation and YAML source

### DIFF
--- a/.chloggen/processor-lookupprocessor-impl.yaml
+++ b/.chloggen/processor-lookupprocessor-impl.yaml
@@ -1,0 +1,10 @@
+change_type: enhancement
+component: processor/lookup
+note: Add lookup processor implementation and YAML source
+issues: [41816]
+
+subtext: |
+  Adds the core lookup processor implementation for enriching telemetry data using external lookups.
+  Includes YAML file source for loading lookup tables from local files.
+
+change_logs: [user]

--- a/processor/lookupprocessor/README.md
+++ b/processor/lookupprocessor/README.md
@@ -9,9 +9,9 @@
 
 ## Description
 
-The lookup processor enriches telemetry signals by performing external lookups to retrieve additional data. Currently supports logs, with metrics and traces support planned.
+The lookup processor enriches telemetry signals by performing external lookups to retrieve additional data. It reads an attribute value, uses it as a key to query a lookup source, and sets the result as a new attribute.
 
-Lookup sources are built into the collector and can be extended through the `WithSources` factory option. Sources can optionally use caching and timeouts to improve performance and reliability.
+Currently supports logs, with metrics and traces support planned.
 
 ## Configuration
 
@@ -19,19 +19,45 @@ Lookup sources are built into the collector and can be extended through the `Wit
 processors:
   lookup:
     source:
-      type: noop  # Source type identifier
-      # Source-specific configuration goes here
+      type: yaml
+      path: /etc/otel/mappings.yaml
+    attributes:
+      - key: user.name
+        from_attribute: user.id
+        default: "Unknown User"
+        action: upsert
+        context: record
 ```
 
-### Source Configuration
-
-The `source` block configures which lookup source to use:
+### Full Configuration
 
 | Field | Description | Default |
 | ----- | ----------- | ------- |
-| `type` | The source type identifier (e.g., `noop`, `yaml`, `dns`) | `noop` |
+| `source.type` | The source type identifier (`noop`, `yaml`) | `noop` |
+| `attributes` | List of attribute enrichment rules (required) | - |
 
-Additional fields depend on the specific source type being used.
+### Attribute Configuration
+
+Each entry in `attributes` defines a lookup rule:
+
+| Field | Description | Default |
+| ----- | ----------- | ------- |
+| `key` | Name of the attribute to set with the lookup result (required) | - |
+| `from_attribute` | Name of the attribute containing the lookup key (required) | - |
+| `default` | Value to use when lookup returns no result | - |
+| `action` | How to handle the result: `insert`, `update`, `upsert` | `upsert` |
+| `context` | Where to read/write attributes: `record`, `resource` | `record` |
+
+### Actions
+
+- **insert**: Only set the attribute if it doesn't already exist
+- **update**: Only set the attribute if it already exists
+- **upsert**: Always set the attribute (default)
+
+### Context
+
+- **record**: Read from and write to record-level attributes (log records, spans, metric data points) (default)
+- **resource**: Read from and write to resource attributes
 
 ## Built-in Sources
 
@@ -44,29 +70,80 @@ processors:
   lookup:
     source:
       type: noop
+    attributes:
+      - key: result
+        from_attribute: key
+        default: "not-found"
 ```
 
-## Caching
+### yaml
 
-Sources can use the built-in caching support via `lookupsource.WrapWithCache`:
+Loads key-value mappings from a YAML file. The file should contain a flat map of string keys to values.
 
 | Field | Description | Default |
 | ----- | ----------- | ------- |
-| `cache.enabled` | Enable caching | `false` |
-| `cache.size` | Maximum number of entries | `1000` |
-| `cache.ttl` | Time-to-live for cached entries | `0` (no expiration) |
+| `path` | Path to the YAML file (required) | - |
+
+```yaml
+processors:
+  lookup:
+    source:
+      type: yaml
+      path: /etc/otel/mappings.yaml
+    attributes:
+      - key: service.display_name
+        from_attribute: service.name
+```
+
+Example mappings file (`mappings.yaml`):
+
+```yaml
+svc-frontend: "Frontend Web App"
+svc-backend: "Backend API Service"
+svc-worker: "Background Worker"
+```
+
+## Benchmarks
+
+Run benchmarks with:
+
+```bash
+make benchmark
+```
+
+### Processor Performance
+
+Measures the full processing pipeline including pdata operations, attribute iteration, value conversion, and telemetry. Uses noop source to isolate processor overhead from source implementation (Apple M4 Pro):
+
+| Scenario | ns/op | B/op | allocs/op |
+|----------|-------|------|-----------|
+| 1 log, 1 attribute | 323 | 696 | 20 |
+| 10 logs, 1 attribute | 1,274 | 3,216 | 74 |
+| 100 logs, 1 attribute | 11,076 | 28,512 | 614 |
+| 100 logs, 3 attributes | 21,604 | 54,113 | 1,014 |
+| 1000 logs, 1 attribute | 122,447 | 280,617 | 6,014 |
+
+### YAML Source Performance
+
+Measures only the source lookup operation (map access), isolated from processor overhead:
+
+| Map Size | ns/op | allocs/op |
+|----------|-------|-----------|
+| 10 entries | 1,418 | 0 |
+| 100 entries | 1,355 | 0 |
+| 1,000 entries | 1,317 | 0 |
+| 10,000 entries | 1,319 | 0 |
 
 ## Custom Sources
 
-Custom lookup sources can be added to the processor using `WithSources`:
+Custom lookup sources can be added using `WithSources`:
 
 ```go
 import (
     "github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor"
-    "github.com/user/otel-lookup-http/httplookup"
+    "github.com/example/httplookup"
 )
 
-// Replace default sources with custom ones
 factories.Processors[lookupprocessor.Type] = lookupprocessor.NewFactoryWithOptions(
     lookupprocessor.WithSources(httplookup.NewFactory()),
 )
@@ -74,20 +151,20 @@ factories.Processors[lookupprocessor.Type] = lookupprocessor.NewFactoryWithOptio
 
 ### Implementing a Source
 
-To create a custom source, implement the `lookupsource.SourceFactory` interface:
-
 ```go
 package mysource
 
 import (
     "context"
+    "errors"
+    "time"
+
     "github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
 )
 
 type Config struct {
     Endpoint string        `mapstructure:"endpoint"`
     Timeout  time.Duration `mapstructure:"timeout"`
-    Cache    lookupsource.CacheConfig `mapstructure:"cache"`
 }
 
 func (c *Config) Validate() error {
@@ -101,9 +178,7 @@ func NewFactory() lookupsource.SourceFactory {
     return lookupsource.NewSourceFactory(
         "mysource",
         func() lookupsource.SourceConfig {
-            return &Config{
-                Timeout: 5 * time.Second,
-            }
+            return &Config{Timeout: 5 * time.Second}
         },
         createSource,
     )
@@ -116,20 +191,15 @@ func createSource(
 ) (lookupsource.Source, error) {
     c := cfg.(*Config)
 
-    lookupFn := func(ctx context.Context, key string) (any, bool, error) {
-        // Perform lookup logic here
-        return value, true, nil
-    }
-
-    // Optionally wrap with caching
-    cache := lookupsource.NewCache(c.Cache)
-    cachedLookup := lookupsource.WrapWithCache(cache, lookupFn)
-
     return lookupsource.NewSource(
-        cachedLookup,
+        func(ctx context.Context, key string) (any, bool, error) {
+            // Perform lookup - return (value, found, error)
+            return "result", true, nil
+        },
         func() string { return "mysource" },
         nil, // start function (optional)
         nil, // shutdown function (optional)
     ), nil
 }
 ```
+

--- a/processor/lookupprocessor/config.go
+++ b/processor/lookupprocessor/config.go
@@ -22,6 +22,17 @@ const (
 	ActionUpsert Action = "upsert"
 )
 
+func (a *Action) UnmarshalText(text []byte) error {
+	str := Action(strings.ToLower(string(text)))
+	switch str {
+	case ActionInsert, ActionUpdate, ActionUpsert:
+		*a = str
+		return nil
+	default:
+		return fmt.Errorf("invalid action %q, must be one of: insert, update, upsert", str)
+	}
+}
+
 // ContextID specifies where to apply the lookup.
 // Matches the semantic used by geoipprocessor.
 type ContextID string
@@ -103,18 +114,6 @@ func (cfg *Config) Validate() error {
 		}
 		if attr.FromAttribute == "" {
 			return fmt.Errorf("attributes[%d]: from_attribute is required", i)
-		}
-
-		switch attr.Action {
-		case "", ActionInsert, ActionUpdate, ActionUpsert:
-		default:
-			return fmt.Errorf("attributes[%d]: invalid action %q, must be one of: insert, update, upsert", i, attr.Action)
-		}
-
-		switch attr.Context {
-		case "", ContextRecord, ContextResource:
-		default:
-			return fmt.Errorf("attributes[%d]: invalid context %q, must be one of: record, resource", i, attr.Context)
 		}
 	}
 

--- a/processor/lookupprocessor/config.go
+++ b/processor/lookupprocessor/config.go
@@ -4,26 +4,133 @@
 package lookupprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor"
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
 )
 
+// Action specifies how to handle the lookup result.
+type Action string
+
+const (
+	ActionInsert Action = "insert"
+	ActionUpdate Action = "update"
+	ActionUpsert Action = "upsert"
+)
+
+// ContextID specifies where to apply the lookup.
+// Matches the semantic used by geoipprocessor.
+type ContextID string
+
+const (
+	ContextRecord   ContextID = "record"
+	ContextResource ContextID = "resource"
+)
+
+func (c *ContextID) UnmarshalText(text []byte) error {
+	str := ContextID(strings.ToLower(string(text)))
+	switch str {
+	case ContextRecord, ContextResource:
+		*c = str
+		return nil
+	default:
+		return fmt.Errorf("invalid context %q, must be one of: record, resource", str)
+	}
+}
+
 type Config struct {
 	Source SourceConfig `mapstructure:"source"`
+
+	// Attributes defines the attribute enrichment rules.
+	// Each rule specifies how to look up a value and where to store the result.
+	Attributes []AttributeConfig `mapstructure:"attributes"`
 }
 
 type SourceConfig struct {
-	// Type is the source type identifier (e.g., "noop", "yaml", "dns").
+	// Type is the source type identifier (e.g., "noop", "yaml").
 	Type string `mapstructure:"type"`
 
-	// Config holds the source-specific configuration.
+	// Config holds the source-specific configuration as raw map.
+	// This is passed to the source factory for parsing.
+	Config map[string]any `mapstructure:",remain"`
+
+	// ParsedConfig holds the parsed source-specific configuration.
 	// This is populated during config unmarshaling based on the Type.
-	Config lookupsource.SourceConfig `mapstructure:"-"`
+	ParsedConfig lookupsource.SourceConfig `mapstructure:"-"`
+}
+
+// AttributeConfig defines a single attribute enrichment rule.
+type AttributeConfig struct {
+	// Key is the name of the attribute to set with the lookup result.
+	// Required.
+	Key string `mapstructure:"key"`
+
+	// FromAttribute is the name of the attribute containing the lookup key.
+	// The value of this attribute will be used to query the source.
+	// Required.
+	FromAttribute string `mapstructure:"from_attribute"`
+
+	// Default is the value to use when the lookup returns no result.
+	// If not set and the lookup fails, no attribute is added.
+	// Optional.
+	Default string `mapstructure:"default"`
+
+	// Action specifies how to handle the lookup result.
+	// Valid values: "insert", "update", "upsert".
+	// Default: "upsert"
+	Action Action `mapstructure:"action"`
+
+	// Context specifies where to read the source attribute and write the result.
+	// Valid values: "record" (log record attributes), "resource" (resource attributes).
+	// Default: "record"
+	Context ContextID `mapstructure:"context"`
 }
 
 var _ component.Config = (*Config)(nil)
 
-func (*Config) Validate() error {
+func (cfg *Config) Validate() error {
+	if len(cfg.Attributes) == 0 {
+		return errors.New("at least one attribute mapping must be configured")
+	}
+
+	for i, attr := range cfg.Attributes {
+		if attr.Key == "" {
+			return fmt.Errorf("attributes[%d]: key is required", i)
+		}
+		if attr.FromAttribute == "" {
+			return fmt.Errorf("attributes[%d]: from_attribute is required", i)
+		}
+
+		switch attr.Action {
+		case "", ActionInsert, ActionUpdate, ActionUpsert:
+		default:
+			return fmt.Errorf("attributes[%d]: invalid action %q, must be one of: insert, update, upsert", i, attr.Action)
+		}
+
+		switch attr.Context {
+		case "", ContextRecord, ContextResource:
+		default:
+			return fmt.Errorf("attributes[%d]: invalid context %q, must be one of: record, resource", i, attr.Context)
+		}
+	}
+
 	return nil
+}
+
+func (a *AttributeConfig) GetAction() Action {
+	if a.Action == "" {
+		return ActionUpsert
+	}
+	return a.Action
+}
+
+func (a *AttributeConfig) GetContext() ContextID {
+	if a.Context == "" {
+		return ContextRecord
+	}
+	return a.Context
 }

--- a/processor/lookupprocessor/doc.go
+++ b/processor/lookupprocessor/doc.go
@@ -4,10 +4,13 @@
 // Package lookupprocessor contains a processor that enriches telemetry data
 // by performing lookups from various sources and adding the results as attributes.
 //
-// Sources are configured via the processor's configuration using the source.type field.
-// Built-in sources include "noop" (for testing) and "yaml" (file-based lookups).
-// Third-party sources can be registered using [NewFactoryWithOptions] with [WithSources].
+// # Built-in Sources
 //
+// Sources are configured via the processor's configuration using the source.type field.
+//
+// # Third-party Sources
+//
+// Custom sources can be registered using [NewFactoryWithOptions] with [WithSources].
 // The public API for creating custom sources is in the lookupsource subpackage.
 // See [lookupsource.NewSourceFactory] and [lookupsource.NewSource] for details.
 package lookupprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor"

--- a/processor/lookupprocessor/factory_test.go
+++ b/processor/lookupprocessor/factory_test.go
@@ -1,0 +1,241 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lookupprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/processor/processortest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
+)
+
+func testAttributeConfig() AttributeConfig {
+	return AttributeConfig{
+		Key:           "test.result",
+		FromAttribute: "test.key",
+	}
+}
+
+func TestNewFactory(t *testing.T) {
+	factory := NewFactory()
+
+	assert.Equal(t, metadata.Type, factory.Type())
+
+	cfg := factory.CreateDefaultConfig()
+	require.NotNil(t, cfg)
+	require.IsType(t, &Config{}, cfg)
+
+	// Default source type should be noop
+	assert.Equal(t, "noop", cfg.(*Config).Source.Type)
+}
+
+func TestNewFactoryWithOptions(t *testing.T) {
+	mockFactory := lookupsource.NewSourceFactory(
+		"mock",
+		func() lookupsource.SourceConfig { return &mockSourceConfig{} },
+		func(_ context.Context, _ lookupsource.CreateSettings, _ lookupsource.SourceConfig) (lookupsource.Source, error) {
+			return lookupsource.NewSource(
+				func(_ context.Context, key string) (any, bool, error) {
+					return "mocked-" + key, true, nil
+				},
+				func() string { return "mock" },
+				nil,
+				nil,
+			), nil
+		},
+	)
+
+	factory := NewFactoryWithOptions(WithSources(mockFactory))
+
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Source.Type = "mock"
+	cfg.Attributes = []AttributeConfig{testAttributeConfig()}
+
+	settings := processortest.NewNopSettings(metadata.Type)
+	sink := consumertest.NewNop()
+
+	proc, err := factory.CreateLogs(t.Context(), settings, cfg, sink)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+
+	host := &testHost{}
+	require.NoError(t, proc.Start(t.Context(), host))
+	require.NoError(t, proc.Shutdown(t.Context()))
+}
+
+func TestFactoryCreatesLogsProcessor(t *testing.T) {
+	factory := NewFactory()
+
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Attributes = []AttributeConfig{testAttributeConfig()}
+
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	proc, err := factory.CreateLogs(t.Context(), settings, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+
+	host := &testHost{}
+	require.NoError(t, proc.Start(t.Context(), host))
+	require.NoError(t, proc.Shutdown(t.Context()))
+}
+
+func TestFactoryRejectsTracesProcessor(t *testing.T) {
+	factory := NewFactory()
+
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Attributes = []AttributeConfig{testAttributeConfig()}
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	_, err := factory.CreateTraces(t.Context(), settings, cfg, consumertest.NewNop())
+	require.Error(t, err)
+}
+
+func TestFactoryRejectsMetricsProcessor(t *testing.T) {
+	factory := NewFactory()
+
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Attributes = []AttributeConfig{testAttributeConfig()}
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	_, err := factory.CreateMetrics(t.Context(), settings, cfg, consumertest.NewNop())
+	require.Error(t, err)
+}
+
+func TestFactoryUnknownSourceType(t *testing.T) {
+	factory := NewFactory()
+
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Source.Type = "unknown"
+	cfg.Attributes = []AttributeConfig{testAttributeConfig()}
+
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	_, err := factory.CreateLogs(t.Context(), settings, cfg, consumertest.NewNop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown source type")
+}
+
+func TestWithSourcesReplacesDefaults(t *testing.T) {
+	customFactory := lookupsource.NewSourceFactory(
+		"custom",
+		func() lookupsource.SourceConfig { return &mockSourceConfig{} },
+		func(_ context.Context, _ lookupsource.CreateSettings, _ lookupsource.SourceConfig) (lookupsource.Source, error) {
+			return lookupsource.NewSource(
+				func(_ context.Context, _ string) (any, bool, error) {
+					return nil, false, nil
+				},
+				func() string { return "custom" },
+				nil,
+				nil,
+			), nil
+		},
+	)
+
+	// WithSources should replace default sources (noop)
+	factory := NewFactoryWithOptions(WithSources(customFactory))
+
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Attributes = []AttributeConfig{testAttributeConfig()}
+	// noop should not be available anymore
+	cfg.Source.Type = "noop"
+
+	settings := processortest.NewNopSettings(metadata.Type)
+	_, err := factory.CreateLogs(t.Context(), settings, cfg, consumertest.NewNop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown source type")
+
+	// custom should be available
+	cfg.Source.Type = "custom"
+	proc, err := factory.CreateLogs(t.Context(), settings, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+}
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr string
+	}{
+		{
+			name:    "no attributes",
+			cfg:     &Config{},
+			wantErr: "at least one attribute mapping",
+		},
+		{
+			name: "missing key",
+			cfg: &Config{
+				Attributes: []AttributeConfig{{FromAttribute: "test"}},
+			},
+			wantErr: "key is required",
+		},
+		{
+			name: "missing from_attribute",
+			cfg: &Config{
+				Attributes: []AttributeConfig{{Key: "test"}},
+			},
+			wantErr: "from_attribute is required",
+		},
+		{
+			name: "invalid action",
+			cfg: &Config{
+				Attributes: []AttributeConfig{{Key: "test", FromAttribute: "src", Action: "invalid"}},
+			},
+			wantErr: "invalid action",
+		},
+		{
+			name: "invalid context",
+			cfg: &Config{
+				Attributes: []AttributeConfig{{Key: "test", FromAttribute: "src", Context: "invalid"}},
+			},
+			wantErr: "invalid context",
+		},
+		{
+			name: "valid config",
+			cfg: &Config{
+				Source: SourceConfig{Type: "noop"},
+				Attributes: []AttributeConfig{
+					{Key: "test.result", FromAttribute: "test.key"},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid config with all options",
+			cfg: &Config{
+				Source: SourceConfig{Type: "noop"},
+				Attributes: []AttributeConfig{
+					{
+						Key:           "user.name",
+						FromAttribute: "user.id",
+						Default:       "Unknown",
+						Action:        ActionUpsert,
+						Context:       ContextRecord,
+					},
+				},
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+

--- a/processor/lookupprocessor/factory_test.go
+++ b/processor/lookupprocessor/factory_test.go
@@ -185,20 +185,6 @@ func TestConfigValidation(t *testing.T) {
 			wantErr: "from_attribute is required",
 		},
 		{
-			name: "invalid action",
-			cfg: &Config{
-				Attributes: []AttributeConfig{{Key: "test", FromAttribute: "src", Action: "invalid"}},
-			},
-			wantErr: "invalid action",
-		},
-		{
-			name: "invalid context",
-			cfg: &Config{
-				Attributes: []AttributeConfig{{Key: "test", FromAttribute: "src", Context: "invalid"}},
-			},
-			wantErr: "invalid context",
-		},
-		{
 			name: "valid config",
 			cfg: &Config{
 				Source: SourceConfig{Type: "noop"},
@@ -239,3 +225,64 @@ func TestConfigValidation(t *testing.T) {
 	}
 }
 
+func TestActionUnmarshalText(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    Action
+		wantErr bool
+	}{
+		{"insert", ActionInsert, false},
+		{"INSERT", ActionInsert, false},
+		{"Insert", ActionInsert, false},
+		{"update", ActionUpdate, false},
+		{"UPDATE", ActionUpdate, false},
+		{"upsert", ActionUpsert, false},
+		{"UPSERT", ActionUpsert, false},
+		{"invalid", "", true},
+		{"", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var a Action
+			err := a.UnmarshalText([]byte(tt.input))
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid action")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, a)
+			}
+		})
+	}
+}
+
+func TestContextIDUnmarshalText(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    ContextID
+		wantErr bool
+	}{
+		{"record", ContextRecord, false},
+		{"RECORD", ContextRecord, false},
+		{"Record", ContextRecord, false},
+		{"resource", ContextResource, false},
+		{"RESOURCE", ContextResource, false},
+		{"invalid", "", true},
+		{"", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var c ContextID
+			err := c.UnmarshalText([]byte(tt.input))
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid context")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
+		})
+	}
+}

--- a/processor/lookupprocessor/go.mod
+++ b/processor/lookupprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/looku
 go 1.24.0
 
 require (
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.49.1-0.20260109195331-fbd5d3f9faae
 	go.opentelemetry.io/collector/component/componenttest v0.143.1-0.20260109195331-fbd5d3f9faae
@@ -15,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/processor/processortest v0.143.1-0.20260109195331-fbd5d3f9faae
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -22,7 +24,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
@@ -52,7 +53,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.39.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // Can be removed after 0.144.0 release

--- a/processor/lookupprocessor/helpers_test.go
+++ b/processor/lookupprocessor/helpers_test.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lookupprocessor
+
+import "go.opentelemetry.io/collector/component"
+
+type mockSourceConfig struct{}
+
+func (*mockSourceConfig) Validate() error { return nil }
+
+type testHost struct{}
+
+func (*testHost) GetExtensions() map[component.ID]component.Component {
+	return nil
+}

--- a/processor/lookupprocessor/internal/source/noop/noop_test.go
+++ b/processor/lookupprocessor/internal/source/noop/noop_test.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package noop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
+)
+
+func TestNewFactory(t *testing.T) {
+	factory := NewFactory()
+	require.NotNil(t, factory)
+	assert.Equal(t, "noop", factory.Type())
+}
+
+func TestConfig(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	require.NotNil(t, cfg)
+
+	// Config should validate successfully
+	require.NoError(t, cfg.Validate())
+}
+
+func TestCreateSource(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	settings := lookupsource.CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+
+	source, err := factory.CreateSource(t.Context(), settings, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, source)
+
+	assert.Equal(t, "noop", source.Type())
+}
+
+func TestNoopSourceLookup(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	settings := lookupsource.CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+
+	source, err := factory.CreateSource(t.Context(), settings, cfg)
+	require.NoError(t, err)
+
+	// Noop source always returns not found
+	val, found, err := source.Lookup(t.Context(), "any-key")
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Nil(t, val)
+
+	// Try different keys - all should return not found
+	for _, key := range []string{"", "key1", "user001", "test"} {
+		val, found, err = source.Lookup(t.Context(), key)
+		require.NoError(t, err)
+		assert.False(t, found, "key %q should not be found", key)
+		assert.Nil(t, val)
+	}
+}
+
+func TestNoopSourceStartShutdown(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	settings := lookupsource.CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+
+	source, err := factory.CreateSource(t.Context(), settings, cfg)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+
+	// Start should succeed
+	require.NoError(t, source.Start(t.Context(), host))
+
+	// Shutdown should succeed
+	require.NoError(t, source.Shutdown(t.Context()))
+}

--- a/processor/lookupprocessor/internal/source/yaml/yaml.go
+++ b/processor/lookupprocessor/internal/source/yaml/yaml.go
@@ -1,0 +1,103 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package yaml provides a YAML file-based lookup source.
+package yaml // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/internal/source/yaml"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+	"gopkg.in/yaml.v3"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
+)
+
+const sourceType = "yaml"
+
+// Config is the configuration for the YAML lookup source.
+type Config struct {
+	// Path is the path to the YAML file containing key-value mappings.
+	// The file should contain a flat map of string keys to values.
+	// Required.
+	Path string `mapstructure:"path"`
+}
+
+// Validate implements lookupsource.SourceConfig.
+func (c *Config) Validate() error {
+	if c.Path == "" {
+		return errors.New("path is required")
+	}
+	return nil
+}
+
+// NewFactory creates a factory for the YAML source.
+func NewFactory() lookupsource.SourceFactory {
+	return lookupsource.NewSourceFactory(
+		sourceType,
+		createDefaultConfig,
+		createSource,
+	)
+}
+
+func createDefaultConfig() lookupsource.SourceConfig {
+	return &Config{}
+}
+
+func createSource(
+	_ context.Context,
+	_ lookupsource.CreateSettings,
+	cfg lookupsource.SourceConfig,
+) (lookupsource.Source, error) {
+	yamlCfg := cfg.(*Config)
+	s := &yamlSource{
+		path: yamlCfg.Path,
+		data: make(map[string]any),
+	}
+
+	return lookupsource.NewSource(
+		s.lookup,
+		func() string { return sourceType },
+		s.start,
+		nil, // no shutdown needed
+	), nil
+}
+
+// yamlSource holds the loaded YAML data.
+type yamlSource struct {
+	path string
+	mu   sync.RWMutex
+	data map[string]any
+}
+
+// start loads the YAML file.
+func (s *yamlSource) start(_ context.Context, _ component.Host) error {
+	content, err := os.ReadFile(s.path)
+	if err != nil {
+		return fmt.Errorf("failed to read YAML file %q: %w", s.path, err)
+	}
+
+	var data map[string]any
+	if err := yaml.Unmarshal(content, &data); err != nil {
+		return fmt.Errorf("failed to parse YAML file %q: %w", s.path, err)
+	}
+
+	s.mu.Lock()
+	s.data = data
+	s.mu.Unlock()
+
+	return nil
+}
+
+// lookup retrieves a value from the loaded YAML data.
+func (s *yamlSource) lookup(_ context.Context, key string) (any, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	val, found := s.data[key]
+	return val, found, nil
+}

--- a/processor/lookupprocessor/internal/source/yaml/yaml_benchmark_test.go
+++ b/processor/lookupprocessor/internal/source/yaml/yaml_benchmark_test.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
+)
+
+func BenchmarkYAMLSourceLookup(b *testing.B) {
+	sizes := []int{10, 100, 1000, 10000}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("entries_%d", size), func(b *testing.B) {
+			source := createBenchmarkSource(b, size)
+			keys := generateKeys(size, 100)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				for _, key := range keys {
+					_, _, _ = source.Lookup(b.Context(), key)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkYAMLSourceLookupParallel(b *testing.B) {
+	source := createBenchmarkSource(b, 1000)
+	keys := generateKeys(1000, 100)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(4)
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _, _ = source.Lookup(b.Context(), keys[i%len(keys)])
+			i++
+		}
+	})
+}
+
+func createBenchmarkSource(b *testing.B, numEntries int) lookupsource.Source {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	yamlPath := filepath.Join(tmpDir, "mappings.yaml")
+
+	var content strings.Builder
+	for i := range numEntries {
+		fmt.Fprintf(&content, "key%d: value%d\n", i, i)
+	}
+	err := os.WriteFile(yamlPath, []byte(content.String()), 0o600)
+	require.NoError(b, err)
+
+	factory := NewFactory()
+	cfg := &Config{Path: yamlPath}
+
+	source, err := factory.CreateSource(b.Context(), lookupsource.CreateSettings{}, cfg)
+	require.NoError(b, err)
+
+	err = source.Start(b.Context(), componenttest.NewNopHost())
+	require.NoError(b, err)
+
+	b.Cleanup(func() {
+		_ = source.Shutdown(b.Context())
+	})
+
+	return source
+}
+
+func generateKeys(mapSize, numKeys int) []string {
+	keys := make([]string, numKeys)
+	for i := range numKeys {
+		keys[i] = fmt.Sprintf("key%d", i%mapSize)
+	}
+	return keys
+}

--- a/processor/lookupprocessor/internal/source/yaml/yaml_test.go
+++ b/processor/lookupprocessor/internal/source/yaml/yaml_test.go
@@ -1,0 +1,156 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package yaml
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
+)
+
+func TestNewFactory(t *testing.T) {
+	factory := NewFactory()
+	require.NotNil(t, factory)
+	assert.Equal(t, "yaml", factory.Type())
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{
+			name:    "empty path",
+			config:  &Config{},
+			wantErr: true,
+		},
+		{
+			name:    "valid path",
+			config:  &Config{Path: "/path/to/file.yaml"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestYAMLSourceLookup(t *testing.T) {
+	// Create a temporary YAML file
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "mappings.yaml")
+
+	yamlContent := `
+user001: "Alice Johnson"
+user002: "Bob Smith"
+user003: "Charlie Brown"
+svc-frontend: "Frontend Web App"
+svc-backend: "Backend API Service"
+numeric_key: 42
+bool_key: true
+`
+	err := os.WriteFile(yamlPath, []byte(yamlContent), 0o600)
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	cfg := &Config{Path: yamlPath}
+
+	settings := lookupsource.CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+
+	source, err := factory.CreateSource(t.Context(), settings, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, source)
+
+	// Start the source to load the file
+	host := componenttest.NewNopHost()
+	require.NoError(t, source.Start(t.Context(), host))
+
+	// Test lookups
+	tests := []struct {
+		key      string
+		expected any
+		found    bool
+	}{
+		{"user001", "Alice Johnson", true},
+		{"user002", "Bob Smith", true},
+		{"user003", "Charlie Brown", true},
+		{"svc-frontend", "Frontend Web App", true},
+		{"svc-backend", "Backend API Service", true},
+		{"numeric_key", 42, true},
+		{"bool_key", true, true},
+		{"nonexistent", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			val, found, err := source.Lookup(t.Context(), tt.key)
+			require.NoError(t, err)
+			assert.Equal(t, tt.found, found)
+			if tt.found {
+				assert.Equal(t, tt.expected, val)
+			}
+		})
+	}
+
+	// Shutdown
+	require.NoError(t, source.Shutdown(t.Context()))
+}
+
+func TestYAMLSourceFileNotFound(t *testing.T) {
+	factory := NewFactory()
+	cfg := &Config{Path: "/nonexistent/path/to/file.yaml"}
+
+	settings := lookupsource.CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+
+	source, err := factory.CreateSource(t.Context(), settings, cfg)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	err = source.Start(t.Context(), host)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read YAML file")
+}
+
+func TestYAMLSourceInvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "invalid.yaml")
+
+	// Write invalid YAML
+	err := os.WriteFile(yamlPath, []byte("not: valid: yaml: content: ["), 0o600)
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	cfg := &Config{Path: yamlPath}
+
+	settings := lookupsource.CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+
+	source, err := factory.CreateSource(t.Context(), settings, cfg)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	err = source.Start(t.Context(), host)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse YAML file")
+}

--- a/processor/lookupprocessor/lookupsource/cache_test.go
+++ b/processor/lookupprocessor/lookupsource/cache_test.go
@@ -1,0 +1,108 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lookupsource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCache(t *testing.T) {
+	cfg := CacheConfig{
+		Enabled: true,
+		Size:    100,
+		TTL:     5 * time.Minute,
+	}
+	cache := NewCache(cfg)
+	require.NotNil(t, cache)
+}
+
+func TestCacheStub(t *testing.T) {
+	// The cache is a stub for now (full implementation in Branch 3)
+	cache := NewCache(CacheConfig{Enabled: true, Size: 100})
+
+	// Get always returns not found (stub)
+	val, found := cache.Get("key")
+	assert.False(t, found)
+	assert.Nil(t, val)
+
+	// Set is a no-op (stub)
+	cache.Set("key", "value")
+
+	// Still not found after Set (stub behavior)
+	val, found = cache.Get("key")
+	assert.False(t, found)
+	assert.Nil(t, val)
+
+	// Clear is a no-op (stub)
+	cache.Clear()
+}
+
+func TestWrapWithCacheDisabled(t *testing.T) {
+	lookupCount := 0
+	baseFn := func(_ context.Context, key string) (any, bool, error) {
+		lookupCount++
+		return "value-" + key, true, nil
+	}
+
+	// Disabled cache should not wrap
+	cache := NewCache(CacheConfig{Enabled: false})
+	wrappedFn := WrapWithCache(cache, baseFn)
+
+	// Multiple calls should all hit the base function
+	_, _, _ = wrappedFn(t.Context(), "key1")
+	_, _, _ = wrappedFn(t.Context(), "key1")
+	_, _, _ = wrappedFn(t.Context(), "key1")
+
+	assert.Equal(t, 3, lookupCount)
+}
+
+func TestWrapWithCacheNil(t *testing.T) {
+	lookupCount := 0
+	baseFn := func(_ context.Context, key string) (any, bool, error) {
+		lookupCount++
+		return "value-" + key, true, nil
+	}
+
+	// Nil cache should not wrap
+	wrappedFn := WrapWithCache(nil, baseFn)
+
+	val, found, err := wrappedFn(t.Context(), "key1")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "value-key1", val)
+	assert.Equal(t, 1, lookupCount)
+}
+
+func TestWrapWithCacheEnabled(t *testing.T) {
+	// Note: Since cache is a stub, this test verifies the wrapper logic
+	// but cache.Get always returns false and cache.Set is a no-op
+
+	lookupCount := 0
+	baseFn := func(_ context.Context, key string) (any, bool, error) {
+		lookupCount++
+		return "value-" + key, true, nil
+	}
+
+	cache := NewCache(CacheConfig{Enabled: true, Size: 100})
+	wrappedFn := WrapWithCache(cache, baseFn)
+
+	// First call should hit base function
+	val, found, err := wrappedFn(t.Context(), "key1")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "value-key1", val)
+	assert.Equal(t, 1, lookupCount)
+
+	// Second call also hits base function (cache is stub)
+	val, found, err = wrappedFn(t.Context(), "key1")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "value-key1", val)
+	assert.Equal(t, 2, lookupCount) // Would be 1 with real cache
+}

--- a/processor/lookupprocessor/lookupsource/factory.go
+++ b/processor/lookupprocessor/lookupsource/factory.go
@@ -36,7 +36,7 @@ type SourceFactory interface {
 // NewSourceFactory creates a new SourceFactory.
 //
 // Parameters:
-//   - typ: The source type identifier (e.g., "yaml", "http", "dns").
+//   - typ: The source type identifier (e.g., "yaml", "http").
 //   - createDefaultConfig: Returns the default configuration for this source.
 //   - createSource: Creates a Source instance from configuration.
 //

--- a/processor/lookupprocessor/lookupsource/factory_test.go
+++ b/processor/lookupprocessor/lookupsource/factory_test.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lookupsource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+)
+
+type testConfig struct {
+	Value string
+}
+
+func (*testConfig) Validate() error {
+	return nil
+}
+
+func TestNewSourceFactory(t *testing.T) {
+	factory := NewSourceFactory(
+		"test",
+		func() SourceConfig { return &testConfig{Value: "default"} },
+		func(_ context.Context, _ CreateSettings, cfg SourceConfig) (Source, error) {
+			tc := cfg.(*testConfig)
+			return NewSource(
+				func(_ context.Context, _ string) (any, bool, error) {
+					return tc.Value, true, nil
+				},
+				func() string { return "test" },
+				nil,
+				nil,
+			), nil
+		},
+	)
+
+	require.NotNil(t, factory)
+	assert.Equal(t, "test", factory.Type())
+
+	// Test default config
+	defaultCfg := factory.CreateDefaultConfig()
+	require.NotNil(t, defaultCfg)
+	assert.Equal(t, "default", defaultCfg.(*testConfig).Value)
+
+	// Test source creation
+	settings := CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+	source, err := factory.CreateSource(t.Context(), settings, defaultCfg)
+	require.NoError(t, err)
+	require.NotNil(t, source)
+	assert.Equal(t, "test", source.Type())
+
+	// Verify lookup works
+	val, found, err := source.Lookup(t.Context(), "key")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "default", val)
+}
+
+func TestSourceFactoryNilFunctions(t *testing.T) {
+	factory := NewSourceFactory("empty", nil, nil)
+
+	assert.Equal(t, "empty", factory.Type())
+	assert.Nil(t, factory.CreateDefaultConfig())
+
+	settings := CreateSettings{
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+	source, err := factory.CreateSource(t.Context(), settings, nil)
+	require.NoError(t, err)
+	assert.Nil(t, source)
+}

--- a/processor/lookupprocessor/lookupsource/source_test.go
+++ b/processor/lookupprocessor/lookupsource/source_test.go
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lookupsource
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+)
+
+func TestNewSource(t *testing.T) {
+	lookupCalled := false
+	source := NewSource(
+		func(_ context.Context, key string) (any, bool, error) {
+			lookupCalled = true
+			return "value-for-" + key, true, nil
+		},
+		func() string { return "test" },
+		nil,
+		nil,
+	)
+
+	require.NotNil(t, source)
+	assert.Equal(t, "test", source.Type())
+
+	val, found, err := source.Lookup(t.Context(), "key1")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "value-for-key1", val)
+	assert.True(t, lookupCalled)
+}
+
+func TestSourceStartShutdown(t *testing.T) {
+	startCalled := false
+	shutdownCalled := false
+
+	source := NewSource(
+		func(_ context.Context, _ string) (any, bool, error) {
+			return nil, false, nil
+		},
+		func() string { return "test" },
+		func(_ context.Context, _ component.Host) error {
+			startCalled = true
+			return nil
+		},
+		func(_ context.Context) error {
+			shutdownCalled = true
+			return nil
+		},
+	)
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, source.Start(t.Context(), host))
+	assert.True(t, startCalled)
+
+	require.NoError(t, source.Shutdown(t.Context()))
+	assert.True(t, shutdownCalled)
+}
+
+func TestSourceNilFunctions(t *testing.T) {
+	// Source with nil functions should not panic
+	source := NewSource(nil, nil, nil, nil)
+
+	// Lookup returns (nil, false, nil) when function is nil
+	val, found, err := source.Lookup(t.Context(), "key")
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Nil(t, val)
+
+	// Type returns "unknown" when function is nil
+	assert.Equal(t, "unknown", source.Type())
+
+	// Start and Shutdown don't error when functions are nil
+	host := componenttest.NewNopHost()
+	require.NoError(t, source.Start(t.Context(), host))
+	require.NoError(t, source.Shutdown(t.Context()))
+}
+
+func TestSourceLookupError(t *testing.T) {
+	expectedErr := errors.New("lookup failed")
+	source := NewSource(
+		func(_ context.Context, _ string) (any, bool, error) {
+			return nil, false, expectedErr
+		},
+		func() string { return "test" },
+		nil,
+		nil,
+	)
+
+	_, _, err := source.Lookup(t.Context(), "key")
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestSourceStartError(t *testing.T) {
+	expectedErr := errors.New("start failed")
+	source := NewSource(
+		func(_ context.Context, _ string) (any, bool, error) {
+			return nil, false, nil
+		},
+		func() string { return "test" },
+		func(_ context.Context, _ component.Host) error {
+			return expectedErr
+		},
+		nil,
+	)
+
+	host := componenttest.NewNopHost()
+	err := source.Start(t.Context(), host)
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}

--- a/processor/lookupprocessor/processor.go
+++ b/processor/lookupprocessor/processor.go
@@ -5,8 +5,11 @@ package lookupprocessor // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 
@@ -14,12 +17,17 @@ import (
 )
 
 type lookupProcessor struct {
-	source lookupsource.Source
-	logger *zap.Logger
+	source     lookupsource.Source
+	attributes []AttributeConfig
+	logger     *zap.Logger
 }
 
-func newLookupProcessor(source lookupsource.Source, logger *zap.Logger) *lookupProcessor {
-	return &lookupProcessor{source: source, logger: logger}
+func newLookupProcessor(source lookupsource.Source, cfg *Config, logger *zap.Logger) *lookupProcessor {
+	return &lookupProcessor{
+		source:     source,
+		attributes: cfg.Attributes,
+		logger:     logger,
+	}
 }
 
 func (p *lookupProcessor) Start(ctx context.Context, host component.Host) error {
@@ -30,7 +38,114 @@ func (p *lookupProcessor) Shutdown(ctx context.Context) error {
 	return p.source.Shutdown(ctx)
 }
 
-func (*lookupProcessor) processLogs(_ context.Context, ld plog.Logs) (plog.Logs, error) {
-	// Skeleton: passthrough for now
+func (p *lookupProcessor) processLogs(ctx context.Context, ld plog.Logs) (plog.Logs, error) {
+	resourceLogs := ld.ResourceLogs()
+	for i := 0; i < resourceLogs.Len(); i++ {
+		rl := resourceLogs.At(i)
+		resourceAttrs := rl.Resource().Attributes()
+
+		// Process resource-level attributes
+		for _, attrCfg := range p.attributes {
+			if attrCfg.GetContext() == ContextResource {
+				p.processAttribute(ctx, resourceAttrs, attrCfg)
+			}
+		}
+
+		// Process log records
+		scopeLogs := rl.ScopeLogs()
+		for j := 0; j < scopeLogs.Len(); j++ {
+			sl := scopeLogs.At(j)
+			logRecords := sl.LogRecords()
+			for k := 0; k < logRecords.Len(); k++ {
+				lr := logRecords.At(k)
+				logAttrs := lr.Attributes()
+
+				for _, attrCfg := range p.attributes {
+					if attrCfg.GetContext() == ContextRecord {
+						p.processAttribute(ctx, logAttrs, attrCfg)
+					}
+				}
+			}
+		}
+	}
+
 	return ld, nil
+}
+
+func (p *lookupProcessor) processAttribute(ctx context.Context, attrs pcommon.Map, cfg AttributeConfig) {
+	sourceVal, exists := attrs.Get(cfg.FromAttribute)
+	if !exists {
+		return
+	}
+
+	key := valueToString(sourceVal)
+	if key == "" {
+		return
+	}
+
+	result, found, err := p.source.Lookup(ctx, key)
+	if err != nil {
+		p.logger.Debug("lookup failed",
+			zap.String("key", key),
+			zap.String("from_attribute", cfg.FromAttribute),
+			zap.Error(err),
+		)
+		return
+	}
+
+	action := cfg.GetAction()
+
+	var shouldSet bool
+	if action == ActionUpsert {
+		shouldSet = true
+	} else {
+		_, targetExists := attrs.Get(cfg.Key)
+		shouldSet = (action == ActionInsert && !targetExists) || (action == ActionUpdate && targetExists)
+	}
+
+	if !shouldSet {
+		return
+	}
+
+	if !found {
+		if cfg.Default == "" {
+			return
+		}
+		attrs.PutStr(cfg.Key, cfg.Default)
+		return
+	}
+
+	putAny(attrs, cfg.Key, result)
+}
+
+func putAny(attrs pcommon.Map, key string, v any) {
+	switch val := v.(type) {
+	case string:
+		attrs.PutStr(key, val)
+	case int:
+		attrs.PutInt(key, int64(val))
+	case int64:
+		attrs.PutInt(key, val)
+	case float64:
+		attrs.PutDouble(key, val)
+	case bool:
+		attrs.PutBool(key, val)
+	default:
+		attrs.PutStr(key, fmt.Sprintf("%v", v))
+	}
+}
+
+func valueToString(v pcommon.Value) string {
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		return v.Str()
+	case pcommon.ValueTypeInt:
+		return strconv.FormatInt(v.Int(), 10)
+	case pcommon.ValueTypeDouble:
+		return strconv.FormatFloat(v.Double(), 'g', -1, 64)
+	case pcommon.ValueTypeBool:
+		return strconv.FormatBool(v.Bool())
+	default:
+		return v.AsString()
+	}
 }

--- a/processor/lookupprocessor/processor_benchmark_test.go
+++ b/processor/lookupprocessor/processor_benchmark_test.go
@@ -1,0 +1,194 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lookupprocessor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/processor/processortest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/internal/metadata"
+)
+
+// BenchmarkProcessorLookup benchmarks the core processor overhead.
+// Uses noop source to isolate processor logic from source implementation.
+func BenchmarkProcessorLookup(b *testing.B) {
+	benchmarks := []struct {
+		name          string
+		numLogRecords int
+		numAttributes int
+	}{
+		{"1_log_1_attr", 1, 1},
+		{"10_logs_1_attr", 10, 1},
+		{"100_logs_1_attr", 100, 1},
+		{"100_logs_3_attrs", 100, 3},
+		{"1000_logs_1_attr", 1000, 1},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			runLookupBenchmark(b, bm.numLogRecords, bm.numAttributes)
+		})
+	}
+}
+
+func runLookupBenchmark(b *testing.B, numLogRecords, numAttributes int) {
+	attrs := make([]AttributeConfig, numAttributes)
+	for i := range numAttributes {
+		attrs[i] = AttributeConfig{
+			Key:           fmt.Sprintf("result.%d", i),
+			FromAttribute: fmt.Sprintf("lookup.key.%d", i),
+			Default:       "default-value", // noop returns not found, so use default
+			Action:        ActionUpsert,
+			Context:       ContextRecord,
+		}
+	}
+
+	factory := NewFactory()
+	cfg := &Config{
+		Source:     SourceConfig{Type: "noop"},
+		Attributes: attrs,
+	}
+
+	p, err := factory.CreateLogs(b.Context(), processortest.NewNopSettings(metadata.Type), cfg, dropLogsSink{})
+	require.NoError(b, err)
+
+	require.NoError(b, p.Start(b.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(b, p.Shutdown(b.Context()))
+	}()
+
+	logs := generateLogs(numLogRecords, numAttributes)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		clone := plog.NewLogs()
+		logs.CopyTo(clone)
+		err := p.ConsumeLogs(b.Context(), clone)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkProcessorThroughput measures parallel throughput.
+func BenchmarkProcessorThroughput(b *testing.B) {
+	factory := NewFactory()
+	cfg := &Config{
+		Source: SourceConfig{Type: "noop"},
+		Attributes: []AttributeConfig{
+			{
+				Key:           "user.name",
+				FromAttribute: "user.id",
+				Default:       "Unknown",
+				Action:        ActionUpsert,
+				Context:       ContextRecord,
+			},
+		},
+	}
+
+	p, err := factory.CreateLogs(b.Context(), processortest.NewNopSettings(metadata.Type), cfg, dropLogsSink{})
+	require.NoError(b, err)
+
+	require.NoError(b, p.Start(b.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(b, p.Shutdown(b.Context()))
+	}()
+
+	logs := generateLogs(100, 1)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetParallelism(4)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			clone := plog.NewLogs()
+			logs.CopyTo(clone)
+			err := p.ConsumeLogs(b.Context(), clone)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkValueToString benchmarks the value conversion function.
+func BenchmarkValueToString(b *testing.B) {
+	logs := plog.NewLogs()
+	lr := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+	b.Run("string", func(b *testing.B) {
+		lr.Attributes().PutStr("key", "test-value")
+		val, _ := lr.Attributes().Get("key")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = valueToString(val)
+		}
+	})
+
+	b.Run("int", func(b *testing.B) {
+		lr.Attributes().PutInt("key", 12345)
+		val, _ := lr.Attributes().Get("key")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = valueToString(val)
+		}
+	})
+
+	b.Run("double", func(b *testing.B) {
+		lr.Attributes().PutDouble("key", 123.456)
+		val, _ := lr.Attributes().Get("key")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = valueToString(val)
+		}
+	})
+
+	b.Run("bool", func(b *testing.B) {
+		lr.Attributes().PutBool("key", true)
+		val, _ := lr.Attributes().Get("key")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = valueToString(val)
+		}
+	})
+}
+
+func generateLogs(numLogRecords, numAttributes int) plog.Logs {
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "benchmark-service")
+
+	sl := rl.ScopeLogs().AppendEmpty()
+	for i := range numLogRecords {
+		lr := sl.LogRecords().AppendEmpty()
+		lr.Body().SetStr(fmt.Sprintf("Log message %d", i))
+		for j := range numAttributes {
+			lr.Attributes().PutStr(fmt.Sprintf("lookup.key.%d", j), fmt.Sprintf("value-%d-%d", i, j))
+		}
+	}
+	return logs
+}
+
+type dropLogsSink struct{}
+
+func (dropLogsSink) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+func (dropLogsSink) ConsumeLogs(context.Context, plog.Logs) error {
+	return nil
+}

--- a/processor/lookupprocessor/processor_test.go
+++ b/processor/lookupprocessor/processor_test.go
@@ -1,0 +1,296 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lookupprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/processor/processortest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor/lookupsource"
+)
+
+func TestProcessorLookup(t *testing.T) {
+	// Create a mock source with test mappings
+	mappings := map[string]any{
+		"user001":      "Alice Johnson",
+		"user002":      "Bob Smith",
+		"user003":      "Charlie Brown",
+		"svc-frontend": "Frontend Web App",
+		"svc-backend":  "Backend API Service",
+	}
+
+	factory := NewFactoryWithOptions(WithSources(mockMapSourceFactory(mappings)))
+	cfg := &Config{
+		Source: SourceConfig{Type: "mockmap"},
+		Attributes: []AttributeConfig{
+			{
+				Key:           "user.name",
+				FromAttribute: "user.id",
+				Default:       "Unknown User",
+				Action:        ActionUpsert,
+				Context:       ContextRecord,
+			},
+			{
+				Key:           "service.display_name",
+				FromAttribute: "service.name",
+				Action:        ActionInsert,
+				Context:       ContextResource,
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	proc, err := factory.CreateLogs(t.Context(), settings, cfg, sink)
+	require.NoError(t, err)
+
+	// Start the processor
+	host := &testHost{}
+	require.NoError(t, proc.Start(t.Context(), host))
+	defer func() { _ = proc.Shutdown(t.Context()) }()
+
+	// Create test logs
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "svc-frontend")
+
+	sl := rl.ScopeLogs().AppendEmpty()
+
+	// Log 1: user001 should resolve to "Alice Johnson"
+	log1 := sl.LogRecords().AppendEmpty()
+	log1.Body().SetStr("User logged in")
+	log1.Attributes().PutStr("user.id", "user001")
+
+	// Log 2: user999 should get default "Unknown User"
+	log2 := sl.LogRecords().AppendEmpty()
+	log2.Body().SetStr("User performed action")
+	log2.Attributes().PutStr("user.id", "user999")
+
+	// Log 3: user002 should resolve to "Bob Smith"
+	log3 := sl.LogRecords().AppendEmpty()
+	log3.Body().SetStr("User logged out")
+	log3.Attributes().PutStr("user.id", "user002")
+
+	// Process the logs
+	err = proc.ConsumeLogs(t.Context(), logs)
+	require.NoError(t, err)
+
+	// Verify the results
+	require.Len(t, sink.AllLogs(), 1)
+	processedLogs := sink.AllLogs()[0]
+
+	// Check resource attributes
+	resource := processedLogs.ResourceLogs().At(0).Resource()
+	serviceName, ok := resource.Attributes().Get("service.display_name")
+	assert.True(t, ok, "service.display_name should be added")
+	assert.Equal(t, "Frontend Web App", serviceName.Str())
+
+	// Check log record attributes
+	logRecords := processedLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	require.Equal(t, 3, logRecords.Len())
+
+	// Log 1: user001 -> "Alice Johnson"
+	userName1, ok := logRecords.At(0).Attributes().Get("user.name")
+	assert.True(t, ok)
+	assert.Equal(t, "Alice Johnson", userName1.Str())
+
+	// Log 2: user999 -> "Unknown User" (default)
+	userName2, ok := logRecords.At(1).Attributes().Get("user.name")
+	assert.True(t, ok)
+	assert.Equal(t, "Unknown User", userName2.Str())
+
+	// Log 3: user002 -> "Bob Smith"
+	userName3, ok := logRecords.At(2).Attributes().Get("user.name")
+	assert.True(t, ok)
+	assert.Equal(t, "Bob Smith", userName3.Str())
+}
+
+func TestProcessorActions(t *testing.T) {
+	// Create a mock source that always returns "found"
+	factory := NewFactoryWithOptions(WithSources(mockSourceFactory("found")))
+
+	tests := []struct {
+		name           string
+		action         Action
+		existingValue  string
+		expectedValue  string
+		expectModified bool
+	}{
+		{
+			name:           "insert on new attribute",
+			action:         ActionInsert,
+			existingValue:  "",
+			expectedValue:  "found",
+			expectModified: true,
+		},
+		{
+			name:           "insert on existing attribute - no change",
+			action:         ActionInsert,
+			existingValue:  "existing",
+			expectedValue:  "existing",
+			expectModified: false,
+		},
+		{
+			name:           "update on existing attribute",
+			action:         ActionUpdate,
+			existingValue:  "existing",
+			expectedValue:  "found",
+			expectModified: true,
+		},
+		{
+			name:           "update on new attribute - no change",
+			action:         ActionUpdate,
+			existingValue:  "",
+			expectedValue:  "",
+			expectModified: false,
+		},
+		{
+			name:           "upsert on new attribute",
+			action:         ActionUpsert,
+			existingValue:  "",
+			expectedValue:  "found",
+			expectModified: true,
+		},
+		{
+			name:           "upsert on existing attribute",
+			action:         ActionUpsert,
+			existingValue:  "existing",
+			expectedValue:  "found",
+			expectModified: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Source: SourceConfig{Type: "mock"},
+				Attributes: []AttributeConfig{
+					{
+						Key:           "result",
+						FromAttribute: "key",
+						Action:        tt.action,
+						Context:       ContextRecord,
+					},
+				},
+			}
+
+			sink := &consumertest.LogsSink{}
+			settings := processortest.NewNopSettings(metadata.Type)
+
+			proc, err := factory.CreateLogs(t.Context(), settings, cfg, sink)
+			require.NoError(t, err)
+
+			host := &testHost{}
+			require.NoError(t, proc.Start(t.Context(), host))
+			defer func() { _ = proc.Shutdown(t.Context()) }()
+
+			// Create test log
+			logs := plog.NewLogs()
+			rl := logs.ResourceLogs().AppendEmpty()
+			lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+			lr.Attributes().PutStr("key", "lookup-key")
+			if tt.existingValue != "" {
+				lr.Attributes().PutStr("result", tt.existingValue)
+			}
+
+			err = proc.ConsumeLogs(t.Context(), logs)
+			require.NoError(t, err)
+
+			processedLogs := sink.AllLogs()[0]
+			resultAttr, exists := processedLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get("result")
+
+			if tt.expectedValue == "" {
+				assert.False(t, exists, "result attribute should not exist")
+			} else {
+				assert.True(t, exists, "result attribute should exist")
+				assert.Equal(t, tt.expectedValue, resultAttr.Str())
+			}
+		})
+	}
+}
+
+func TestProcessorNoSourceAttribute(t *testing.T) {
+	factory := NewFactoryWithOptions(WithSources(mockSourceFactory("found")))
+
+	cfg := &Config{
+		Source: SourceConfig{Type: "mock"},
+		Attributes: []AttributeConfig{
+			{
+				Key:           "result",
+				FromAttribute: "nonexistent",
+				Action:        ActionUpsert,
+				Context:       ContextRecord,
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	settings := processortest.NewNopSettings(metadata.Type)
+
+	proc, err := factory.CreateLogs(t.Context(), settings, cfg, sink)
+	require.NoError(t, err)
+
+	host := &testHost{}
+	require.NoError(t, proc.Start(t.Context(), host))
+	defer func() { _ = proc.Shutdown(t.Context()) }()
+
+	// Create test log without the source attribute
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.Attributes().PutStr("other", "value")
+
+	err = proc.ConsumeLogs(t.Context(), logs)
+	require.NoError(t, err)
+
+	// Result should not be set since source attribute doesn't exist
+	processedLogs := sink.AllLogs()[0]
+	_, exists := processedLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get("result")
+	assert.False(t, exists, "result should not be set when source attribute is missing")
+}
+
+// mockSourceFactory creates a source factory that always returns the given value.
+func mockSourceFactory(value string) lookupsource.SourceFactory {
+	return lookupsource.NewSourceFactory(
+		"mock",
+		func() lookupsource.SourceConfig { return &mockSourceConfig{} },
+		func(_ context.Context, _ lookupsource.CreateSettings, _ lookupsource.SourceConfig) (lookupsource.Source, error) {
+			return lookupsource.NewSource(
+				func(_ context.Context, _ string) (any, bool, error) {
+					return value, true, nil
+				},
+				func() string { return "mock" },
+				nil,
+				nil,
+			), nil
+		},
+	)
+}
+
+// mockMapSourceFactory creates a source factory that looks up values from a map.
+func mockMapSourceFactory(mappings map[string]any) lookupsource.SourceFactory {
+	return lookupsource.NewSourceFactory(
+		"mockmap",
+		func() lookupsource.SourceConfig { return &mockSourceConfig{} },
+		func(_ context.Context, _ lookupsource.CreateSettings, _ lookupsource.SourceConfig) (lookupsource.Source, error) {
+			return lookupsource.NewSource(
+				func(_ context.Context, key string) (any, bool, error) {
+					val, found := mappings[key]
+					return val, found, nil
+				},
+				func() string { return "mockmap" },
+				nil,
+				nil,
+			), nil
+		},
+	)
+}


### PR DESCRIPTION
#### Description

Implements the core lookup processor logic with YAML source support:
- Full processor implementation with attribute lookup
- Lookup at resource and record levels (like geoipprocessor)
- Support for insert/update/upsert/delete actions
- YAML source for static key-value mappings
- Configurable default values when key not found
- Benchmarks for processor and YAML source

#### Link to tracking issue
TODO!!

#### Testing

Finally we have a lot of testing:

- `factory_test.go`: Testing creation of the processor factory with and without custom sources.
- `processor_test.go`: Processor logic, including context appropriate attribute setting, action behavior, missing attributes, etc.
- `lookupsource/factory_test.go`: Testing creation of source factories.
- `lookupsource/source_test.go`: Source implementation testing, interaction with the processor, lifecycle and error handling.
- `lookupsource/cache_test.go`: Not much yet since cache is still a stub but tests WrapWithCache.
- `internal/source/noop/noop_test.go`: Basic testing of a noop source that always returns not found and returns default value.
- `internal/source/yaml/yaml_test.go`: YAML file loading, kv lookups, error handling.

##### Benchmarks

* `processor_benchmark_test.go`: Benchmarks the base lookup processor, setting the baseline of processor overhead without any sources.
* `internal/source/yaml/yaml_benchmark_test.go`: Benchmarks the yaml source without processor overhead.

#### Documentation

TODO
